### PR TITLE
fix: trim breakpoint name, drop dead epsilon fallback, fix README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - Lightweight
 - SSR-safe
 - Auto-cleanup
-- Angular 16 — next
+- Angular 19–21 (use `ngx-mq@1` for Angular 16–18)
 - Well-tested
 
 ## Introduction
@@ -92,7 +92,9 @@ bootstrapApplication(AppComponent, {
 | --------- | ----------------------------------------------------------------- | ----------------- | --------------------------------------------- |
 | `up`      | `bp: string, options?: CreateMediaQueryOptions`                   | `Signal<boolean>` | `true` when viewport width ≥ breakpoint       |
 | `down`    | `bp: string, options?: CreateMediaQueryOptions`                   | `Signal<boolean>` | `true` when viewport width < breakpoint       |
-| `between` | `minBp: string, maxBp: string, options?: CreateMediaQueryOptions` | `Signal<boolean>` | `true` when viewport width is in range [a, b] |
+| `between` | `minBp: string, maxBp: string, options?: CreateMediaQueryOptions` | `Signal<boolean>` | `true` when viewport width is in range [min, max) |
+
+> **Note:** `down` and `between` upper bounds are **exclusive** — epsilon is subtracted from `max` so adjacent ranges (e.g. `down('md')` and `up('md')`) never overlap.
 
 > **Tip:** Wrap these APIs into reusable helpers:
 

--- a/src/lib/utils/breakpoints.utils.spec.ts
+++ b/src/lib/utils/breakpoints.utils.spec.ts
@@ -32,6 +32,17 @@ describe('resolveBreakpoint()', () => {
       expect(resolveBreakpoint('md')).toBe(768);
     });
   });
+
+  it('should trim whitespace around the breakpoint name before lookup', () => {
+    const injector: Injector = Injector.create({
+      providers: [provideBreakpoints({ md: 768 })],
+      parent: TestBed.inject(EnvironmentInjector),
+    });
+
+    runInInjectionContext(injector, () => {
+      expect(resolveBreakpoint('  md  ')).toBe(768);
+    });
+  });
 });
 
 describe('normalizeBreakpoints()', () => {

--- a/src/lib/utils/breakpoints.utils.ts
+++ b/src/lib/utils/breakpoints.utils.ts
@@ -31,7 +31,7 @@ function assertBreakpointExists(bp: string, breakpoints: MqBreakpoints): number 
 export function resolveBreakpoint(bp: string): number {
   const breakpoints: MqBreakpoints = assertBreakpointsProvided();
 
-  return assertBreakpointExists(bp, breakpoints);
+  return assertBreakpointExists(bp.trim(), breakpoints);
 }
 
 export function normalizeBreakpoints(bps: MqBreakpoints): Readonly<MqBreakpoints> {
@@ -63,7 +63,7 @@ export function validateEpsilon(epsilon: number): void {
 }
 
 export function applyMaxEpsilon(value: number): number {
-  const epsilon: number = inject(MQ_BREAKPOINT_EPSILON, { optional: true }) ?? 0.02;
+  const epsilon: number = inject(MQ_BREAKPOINT_EPSILON);
 
   return value - epsilon;
 }


### PR DESCRIPTION
### Description

Removes a dead epsilon fallback, trims the breakpoint name before lookup so padded names resolve, and corrects the docs: `down`/`between` upper bounds are exclusive `[min, max)`, and the supported Angular range is 19–21. No behavior change for valid input.

### Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs

### Checklist

- [x] Builds and tests pass
- [x] Code follows ESLint/Prettier rules
- [x] Docs updated if needed
